### PR TITLE
Fix conflicts with WebApiExtension

### DIFF
--- a/src/ServiceContainer/JsonRpcApiExtension.php
+++ b/src/ServiceContainer/JsonRpcApiExtension.php
@@ -87,6 +87,6 @@ class JsonRpcApiExtension implements Extension
         ));
 
         $definition->addTag(ContextExtension::INITIALIZER_TAG);
-        $container->setDefinition('web_api.context_initializer', $definition);
+        $container->setDefinition('jsonrpc_api.context_initializer', $definition);
     }
 }


### PR DESCRIPTION
Changed service key prefix from "web_api" to "jsonrpc_api".
