### PR TITLE
Fix the pattern for control error message.

### DIFF
--- a/src/Context/JsonRpcClientContext.php
+++ b/src/Context/JsonRpcClientContext.php
@@ -292,7 +292,7 @@ class JsonRpcClientContext implements JsonRpcClientAwareContext
      * @param string|integer $id
      * @param string         $message
      *
-     * @Then /^(?:the )?response should be error with id "([^"]+)", message "([^"]+)"$/
+     * @Then /^(?:the )?response should be error with id "([^"]+)", message "(.+)"$/
      */
     public function theResponseShouldContainErrorWithMessage($id, $message)
     {
@@ -319,7 +319,7 @@ class JsonRpcClientContext implements JsonRpcClientAwareContext
      * @param string         $message
      * @param TableNode      $table
      *
-     * @Then /^(?:the )?response should be error with id "([^"]+)", message "([^"]+)", data:$/
+     * @Then /^(?:the )?response should be error with id "([^"]+)", message "(.+)", data:$/
      */
     public function theResponseShouldContainErrorData($id, $message, TableNode $table)
     {


### PR DESCRIPTION
The problem: We can not check error message, if message have a double quotes.
Solution: Change pattern mask.

Example:
    Then the response should be error with id "50", message "The user "t.repak" is removed."
    Then the response should be error with id "50", message "The user "t.repak" is removed.", data:
