### PR TITLE
Fix system for work with GuzzleHTTP >= 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": ">=5.4",
         "phpunit/phpunit": "~4.4",
         "behat/behat": "~3.0",
-        "graze/guzzle-jsonrpc": "~2.1",
+        "graze/guzzle-jsonrpc": "~2.1|~3.0",
         "symfony/property-access": "~2.1|~3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": ">=5.4",
         "phpunit/phpunit": "~4.4",
         "behat/behat": "~3.0",
-        "graze/guzzle-jsonrpc": "~2.1|~3.0",
+        "graze/guzzle-jsonrpc": "~3.0",
         "symfony/property-access": "~2.1|~3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": ">=5.5",
         "phpunit/phpunit": "~4.4",
         "behat/behat": "~3.0",
         "graze/guzzle-jsonrpc": "~3.0",

--- a/src/ServiceContainer/JsonRpcApiExtension.php
+++ b/src/ServiceContainer/JsonRpcApiExtension.php
@@ -91,7 +91,7 @@ class JsonRpcApiExtension implements Extension
         }
 
         if ($config['defaults']) {
-            $options['defaults'] = $config['defaults'];
+            $options += $config['defaults'];
         }
 
         $clientDefinition = new Definition('Solution\JsonRpcApiExtension\Client\JsonRpcClient');


### PR DESCRIPTION
The many system now works with GuzzleHTTP >= 6.0, because this package created with PSR-7.
And in this commits i move all systems for work with GuzzleHTTP >= 6.0
